### PR TITLE
Fix 'Retrying in...' always being wrong

### DIFF
--- a/retrier.go
+++ b/retrier.go
@@ -18,9 +18,8 @@ type Retrier struct {
 	forever      bool
 	rand         *rand.Rand
 
-	breakNext     bool
-	lastAttemptAt time.Time
-	sleepFunc     func(time.Duration)
+	breakNext bool
+	sleepFunc func(time.Duration)
 
 	intervalCalculator Strategy
 	strategyType       string
@@ -155,7 +154,6 @@ func (r *Retrier) Jitter() time.Duration {
 // for Exponential retry strategy
 func (r *Retrier) MarkAttempt() {
 	r.attemptCount += 1
-	r.lastAttemptAt = time.Now()
 }
 
 // Break causes the Retrier to stop retrying after it completes the next retry cycle
@@ -185,7 +183,7 @@ func (r *Retrier) NextInterval() time.Duration {
 }
 
 func (r *Retrier) String() string {
-	str := fmt.Sprintf("Attempt %d/", r.attemptCount)
+	str := fmt.Sprintf("Attempt %d/", r.attemptCount+1) // +1 because we increment the attempt count after the callback, which is the only useful place to call Retrier.String()
 
 	if r.forever {
 		str = str + "∞"
@@ -195,7 +193,7 @@ func (r *Retrier) String() string {
 
 	nextInterval := r.NextInterval()
 	if nextInterval > 0 {
-		str = str + fmt.Sprintf(" Retrying in %s", nextInterval-time.Since(r.lastAttemptAt))
+		str = str + fmt.Sprintf(" Retrying in %s", nextInterval)
 	} else {
 		str = str + " Retrying immediately"
 	}
@@ -211,9 +209,6 @@ func (r *Retrier) AttemptCount() int {
 // Calling retrier.Do(someFunc) will cause the Retrier to attempt to call the function, and if it returns an error,
 // retry it using the settings provided to it.
 func (r *Retrier) Do(callback func(*Retrier) error) error {
-	// If we don't set lastAttemptAt, if the callback calls `retrier.String()`, it will compare to a zero-value time, which makes it look
-	// like the next retry is ~300 years ago
-	r.lastAttemptAt = time.Now()
 	var err error
 	for {
 		// Perform the action the user has requested we retry

--- a/retrier.go
+++ b/retrier.go
@@ -211,6 +211,9 @@ func (r *Retrier) AttemptCount() int {
 // Calling retrier.Do(someFunc) will cause the Retrier to attempt to call the function, and if it returns an error,
 // retry it using the settings provided to it.
 func (r *Retrier) Do(callback func(*Retrier) error) error {
+	// If we don't set lastAttemptAt, if the callback calls `retrier.String()`, it will compare to a zero-value time, which makes it look
+	// like the next retry is ~300 years ago
+	r.lastAttemptAt = time.Now()
 	var err error
 	for {
 		// Perform the action the user has requested we retry

--- a/retrier.go
+++ b/retrier.go
@@ -191,6 +191,10 @@ func (r *Retrier) String() string {
 		str = str + fmt.Sprintf("%d", r.maxAttempts)
 	}
 
+	if r.attemptCount+1 == r.maxAttempts {
+		return str
+	}
+
 	nextInterval := r.NextInterval()
 	if nextInterval > 0 {
 		str = str + fmt.Sprintf(" Retrying in %s", nextInterval)

--- a/retrier_test.go
+++ b/retrier_test.go
@@ -270,7 +270,7 @@ func TestString_WithFiniteAttemptCount(t *testing.T) {
 		"Attempt 2/5 Retrying in 1s",
 		"Attempt 3/5 Retrying in 1s",
 		"Attempt 4/5 Retrying in 1s",
-		"Attempt 5/5 Retrying in 1s",
+		"Attempt 5/5",
 	}, retryingIns)
 }
 
@@ -295,7 +295,7 @@ func TestString_WithExponentialStrategy(t *testing.T) {
 		"Attempt 2/5 Retrying in 2s",
 		"Attempt 3/5 Retrying in 4s",
 		"Attempt 4/5 Retrying in 8s",
-		"Attempt 5/5 Retrying in 16s",
+		"Attempt 5/5",
 	}, retryingIns)
 }
 
@@ -355,7 +355,7 @@ func TestString_WithNoDelay(t *testing.T) {
 		"Attempt 2/5 Retrying immediately",
 		"Attempt 3/5 Retrying immediately",
 		"Attempt 4/5 Retrying immediately",
-		"Attempt 5/5 Retrying immediately",
+		"Attempt 5/5",
 	}, retryingIns)
 }
 


### PR DESCRIPTION
We were calling `fmt.Sprintf(" Retrying in %s", nextInterval-time.Since(r.lastAttemptAt))`, but on the first attempt, `r.lastAttemptAt` is always zero (== time.Time{}, ~= 300 years ago).

~~This PR sets `r.lastAttemptAt` when the retrier first starts running, so that the 'Retrying in...' will be correct the first time~~

This PR changes the value for retrying in to just be the next retry interval, and not do any of the fancy time calculations, as well as making a couple of little copy changes here and there