### PR TITLE
Manually set next interval

### DIFF
--- a/retrier.go
+++ b/retrier.go
@@ -24,6 +24,7 @@ type Retrier struct {
 
 	intervalCalculator Strategy
 	strategyType       string
+	manualInterval     *time.Duration
 }
 
 type Strategy func(*Retrier) time.Duration
@@ -161,6 +162,11 @@ func (r *Retrier) Break() {
 	r.breakNext = true
 }
 
+// SetNextInterval overrides the strategy for the interval before the next try
+func (r *Retrier) SetNextInterval(d time.Duration) {
+	r.manualInterval = &d
+}
+
 // ShouldGiveUp returns whether the retrier should stop trying do do the thing it's been asked to do
 // It returns true if the retry count is greater than r.maxAttempts, or if r.Break() has been called
 // It returns false if the retrier is supposed to try forever
@@ -179,6 +185,10 @@ func (r *Retrier) ShouldGiveUp() bool {
 // NextInterval returns the next interval that the retrier will use. Behind the scenes, it calls the function generated
 // by either retrier's strategy
 func (r *Retrier) NextInterval() time.Duration {
+	if r.manualInterval != nil {
+		return *r.manualInterval
+	}
+
 	return r.intervalCalculator(r)
 }
 
@@ -232,6 +242,8 @@ func (r *Retrier) DoWithContext(ctx context.Context, callback func(*Retrier) err
 		nextInterval := r.NextInterval()
 
 		r.MarkAttempt()
+
+		r.manualInterval = nil
 
 		// If the last callback called r.Break(), or if we've hit our call limit, bail out and return the last error we got
 		if r.ShouldGiveUp() {

--- a/retrier.go
+++ b/retrier.go
@@ -241,9 +241,10 @@ func (r *Retrier) DoWithContext(ctx context.Context, callback func(*Retrier) err
 		// instead of        2^0, 2^1, 2^2, ..., 2^n seconds (good)
 		nextInterval := r.NextInterval()
 
-		r.MarkAttempt()
-
+		// Reset the manualInterval now that the nextInterval has been acquired.
 		r.manualInterval = nil
+
+		r.MarkAttempt()
 
 		// If the last callback called r.Break(), or if we've hit our call limit, bail out and return the last error we got
 		if r.ShouldGiveUp() {

--- a/retrier_test.go
+++ b/retrier_test.go
@@ -377,33 +377,60 @@ func TestString_WithNoDelay(t *testing.T) {
 	}, retryingIns)
 }
 
-func TestManualInterval_String(t *testing.T) {
+func TestSetNextInterval_Strings(t *testing.T) {
 	t.Parallel()
 
 	strings := []string{}
 
-	manual := []int64{10, 20, 30, 40, 50}
-
 	NewRetrier(
-		WithStrategy(Constant(0)),
+		WithStrategy(Constant(10*time.Second)),
 		WithMaxAttempts(5),
 		WithSleepFunc(dummySleep),
 	).Do(func(r *Retrier) error {
-		attempt := r.AttemptCount()
-		if attempt%2 == 0 {
-			r.SetNextInterval(time.Duration(manual[attempt]) * time.Second)
+		switch r.AttemptCount() {
+		case 1:
+			r.SetNextInterval(0 * time.Second)
+		case 3:
+			r.SetNextInterval(4 * time.Second)
 		}
 		strings = append(strings, r.String())
 		return errDummy
 	})
 
 	assert.Equal(t, []string{
-		"Attempt 1/5 Retrying in 10s",
+		"Attempt 1/5 Retrying in 10s", // default
 		"Attempt 2/5 Retrying immediately",
-		"Attempt 3/5 Retrying in 30s",
-		"Attempt 4/5 Retrying immediately",
+		"Attempt 3/5 Retrying in 10s", // default
+		"Attempt 4/5 Retrying in 4s",
 		"Attempt 5/5",
 	}, strings)
+}
+
+func TestSetNextInterval_Interval(t *testing.T) {
+	t.Parallel()
+
+	insomniac := newInsomniac()
+
+	NewRetrier(
+		WithStrategy(Constant(2*time.Second)),
+		WithMaxAttempts(5),
+		WithSleepFunc(insomniac.sleep),
+	).Do(func(r *Retrier) error {
+		switch r.AttemptCount() {
+		case 1:
+			r.SetNextInterval(0 * time.Second)
+		case 3:
+			r.SetNextInterval(4 * time.Second)
+		}
+		return errDummy
+	})
+
+	assert.Equal(t, []time.Duration{
+		2 * time.Second, // default
+		0 * time.Second, // manual
+		2 * time.Second, // default
+		4 * time.Second, // manual
+	}, insomniac.sleepIntervals)
 }
 
 func withinJitterInterval(this, that time.Duration) bool {


### PR DESCRIPTION
Alternative to #4; add a `SetNextInterval(time.Duration)` method to `roko.Retrier`.

### Manually setting the next interval

Sometimes you only know the desired interval after each try, e.g. a rate-limited API may include a `Retry-After` header. For these cases, the `SetNextInterval(time.Duration)` method can be used. It will apply only to the next interval, and then revert to the configured strategy unless called again on the next attempt.

```Go
// manually specify interval during each try, defaulting to 10 seconds
roko.NewRetrier(
  roko.WithStrategy(Constant(10 * time.Second)),
  roko.WithMaxAttempts(10),
).Do(func(r *roko.Retrier) error {

  response := apiCall() // may be rate limited

  if err := response.HTTPError(); err != nil {
    if response.Status == HttpTooManyRequests {
      if retryAfter, err := strconv.Atoi(response.Header("Retry-After")); err != nil {

        r.SetNextInterval(retryAfter * time.Second) // respect the API

      }
    }
    return err
  }
  return nil
})
```

Closes #4