### PR TITLE
ExponentialSubsecond strategy

### DIFF
--- a/retrier_test.go
+++ b/retrier_test.go
@@ -268,33 +268,33 @@ func TestNextInterval_ExponentialStrategy_WithJitter(t *testing.T) {
 	}
 }
 
-func TestNextInterval_ExponentialMillisecondStrategy_500ms(t *testing.T) {
+func TestNextInterval_ExponentialSubsecondStrategy_100ms(t *testing.T) {
 	t.Parallel()
 
 	insomniac := newInsomniac()
 	err := NewRetrier(
-		WithStrategy(ExponentialSubsecond(500*time.Millisecond)),
+		WithStrategy(ExponentialSubsecond(100*time.Millisecond)),
 		WithMaxAttempts(10),
 		WithSleepFunc(insomniac.sleep),
 	).Do(func(_ *Retrier) error { return errDummy })
 
 	assert.Error(t, err)
 
-	// half a second reaches half a minute over 10 attempts
+	// very short initial delay of 100ms grows to quite short 1 second for 10 attempts
 	assert.Equal(t, []time.Duration{
-		500 * time.Millisecond,
-		839 * time.Millisecond,
-		1408 * time.Millisecond,
-		2364 * time.Millisecond,
-		3968 * time.Millisecond,
-		6661 * time.Millisecond,
-		11180 * time.Millisecond,
-		18765 * time.Millisecond,
-		31498 * time.Millisecond,
+		100 * time.Millisecond,
+		133 * time.Millisecond,
+		177 * time.Millisecond,
+		237 * time.Millisecond,
+		316 * time.Millisecond,
+		421 * time.Millisecond,
+		562 * time.Millisecond,
+		749 * time.Millisecond,
+		1000 * time.Millisecond,
 	}, insomniac.sleepIntervals)
 }
 
-func TestNextInterval_ExponentialMillisecondStrategy_1sec(t *testing.T) {
+func TestNextInterval_ExponentialSubsecondStrategy_1sec(t *testing.T) {
 	t.Parallel()
 
 	insomniac := newInsomniac()
@@ -306,21 +306,47 @@ func TestNextInterval_ExponentialMillisecondStrategy_1sec(t *testing.T) {
 
 	assert.Error(t, err)
 
-	// one second seconds reaches 100 seconds in 10 attempts
+	// reasonable initial delay of 1 second grows to reasonable 30 seconds for 10 attempts
 	assert.Equal(t, []time.Duration{
 		1000 * time.Millisecond,
-		1778 * time.Millisecond,
-		3162 * time.Millisecond,
+		1539 * time.Millisecond,
+		2371 * time.Millisecond,
+		3651 * time.Millisecond,
 		5623 * time.Millisecond,
-		9999 * time.Millisecond,
-		17782 * time.Millisecond,
+		8659 * time.Millisecond,
+		13335 * time.Millisecond,
+		20535 * time.Millisecond,
 		31622 * time.Millisecond,
-		56234 * time.Millisecond,
-		99999 * time.Millisecond,
 	}, insomniac.sleepIntervals)
 }
 
-func TestNextInterval_ExponentialMillisecondStrategy_WithJitter(t *testing.T) {
+func TestNextInterval_ExponentialSubsecondStrategy_5sec(t *testing.T) {
+	t.Parallel()
+
+	insomniac := newInsomniac()
+	err := NewRetrier(
+		WithStrategy(ExponentialSubsecond(5*time.Second)),
+		WithMaxAttempts(10),
+		WithSleepFunc(insomniac.sleep),
+	).Do(func(_ *Retrier) error { return errDummy })
+
+	assert.Error(t, err)
+
+	// quite long 5 second initial delay grows to long-but-reasonable ~6 minutes for 10 attempts
+	assert.Equal(t, []time.Duration{
+		5000 * time.Millisecond,
+		8514 * time.Millisecond,
+		14499 * time.Millisecond,
+		24690 * time.Millisecond,
+		42044 * time.Millisecond,
+		71597 * time.Millisecond,
+		121922 * time.Millisecond,
+		207620 * time.Millisecond,
+		353553 * time.Millisecond,
+	}, insomniac.sleepIntervals)
+}
+
+func TestNextInterval_ExponentialSubsecondStrategy_WithJitter(t *testing.T) {
 	t.Parallel()
 
 	insomniac := newInsomniac()
@@ -335,14 +361,14 @@ func TestNextInterval_ExponentialMillisecondStrategy_WithJitter(t *testing.T) {
 
 	expectedIntervals := []time.Duration{
 		1000 * time.Millisecond,
-		1778 * time.Millisecond,
-		3162 * time.Millisecond,
+		1539 * time.Millisecond,
+		2371 * time.Millisecond,
+		3651 * time.Millisecond,
 		5623 * time.Millisecond,
-		9999 * time.Millisecond,
-		17782 * time.Millisecond,
+		8659 * time.Millisecond,
+		13335 * time.Millisecond,
+		20535 * time.Millisecond,
 		31622 * time.Millisecond,
-		56234 * time.Millisecond,
-		99999 * time.Millisecond,
 	}
 
 	for idx, actualInterval := range insomniac.sleepIntervals {


### PR DESCRIPTION
Introduce a `roko.ExponentialSubsecond` to define exponential back-off more granular than one second.

[Here's](https://www.wolframalpha.com/input?i=y%3D1%5Ex+and+y%3D2%5Ex+and+y%3D3%5Ex+for+x+from+0+to+8+and+y+from+0+to+60) the existing `roko.Exponential` across 10 attempts, with 1, 2 and 3 second base — it only handles integer seconds, so there's no possible curves between these. Note that it always starts at 1 second for the first attempt — the `adjustment` input can change this, but doesn't influence the curve. The _gentlest_ growth (base = 2 seconds) reaches a full minute in 5–6 attempts.

<img width="396" alt="image" src="https://user-images.githubusercontent.com/15759/227068487-66f755a4-c205-476f-ba31-4971f3eb73d0.png">

----

[Here's](https://www.wolframalpha.com/input?i=+y%3D100%5E%28x%2F16+%2B+1%29+and++y%3D500%5E%28x%2F16+%2B+1%29+and+y%3D1000%5E%28x%2F16+%2B+1%29+and+y%3D5000%5E%28x%2F16+%2B+1%29+for+x+from+0+to+8+and+y+from+0+to+60000) the new `roko.ExponentialSubsecond` across 10 attempts, showing initial delays of 100ms, 1 second and 5 second base (but any number of milliseconds is supported).

<img width="478" alt="image" src="https://user-images.githubusercontent.com/15759/227068397-a4823cf9-8a22-49b5-a75b-16e8f8cd0aca.png">


Across 10 attempts, this:
- grows from 100 milliseconds to 1 second
- grows from 1 second to ~30 seconds
- grows from 5 seconds to ~5 minutes

These seem like generally useful curves.
Here's the detailed examples from the tests & code comments:

```
//   100ms → 133ms → 177ms → 237ms → 316ms → 421ms → 562ms → 749ms → 1000ms
//   1.0s  → 1.5s  → 2.4s  → 3.7s  → 5.6s  → 8.7s  → 13.3s → 20.6s → 31.6s
//   5s    → 9s    → 14s   → 25s   → 42s   → 72s   → 120s  → 208s  → 354s
```

For a usage example, I'd like to use this in https://github.com/buildkite/agent/pull/2028 for artifact update retries, with an initial delay of 500ms, which would grow to ~10 seconds delay across 10 attempts, spending a total of ~70 seconds waiting between tries.