### PR TITLE
Fix jitter was always 0

### DIFF
--- a/retrier.go
+++ b/retrier.go
@@ -170,12 +170,12 @@ func NewRetrier(opts ...retrierOpt) *Retrier {
 	return r
 }
 
+// Jitter returns a duration in the interval (0, 1] s if jitter is enabled, or 0 s if it's not
 func (r *Retrier) Jitter() time.Duration {
-	if r.jitter {
-		return time.Duration(r.rand.Float32()) * jitterInterval
+	if !r.jitter {
+		return 0
 	}
-
-	return 0
+	return time.Duration((1.0 - r.rand.Float64()) * float64(jitterInterval))
 }
 
 // MarkAttempt increments the attempt count for the retrier. This affects ShouldGiveUp, and also affects the retry interval

--- a/retrier_test.go
+++ b/retrier_test.go
@@ -185,6 +185,9 @@ func TestNextInterval_ConstantStrategy_WithJitter(t *testing.T) {
 	assert.ErrorIs(t, err, errDummy)
 
 	for _, interval := range insomniac.sleepIntervals {
+		// This will pass occasionally, when the jitter is excatly 0, but it should be good enough
+		// to show that a bug is causing the jitter to always be 0
+		assert.Check(t, interval > expected, "interval: %s, expected: %s", interval, expected) // should be at least the expected interval
 		assert.Check(t, cmp.DeepEqual(interval, expected, opt.DurationWithThreshold(jitterInterval)))
 	}
 }

--- a/retrier_test.go
+++ b/retrier_test.go
@@ -185,9 +185,7 @@ func TestNextInterval_ConstantStrategy_WithJitter(t *testing.T) {
 	assert.ErrorIs(t, err, errDummy)
 
 	for _, interval := range insomniac.sleepIntervals {
-		// This will pass occasionally, when the jitter is excatly 0, but it should be good enough
-		// to show that a bug is causing the jitter to always be 0
-		assert.Check(t, interval > expected, "interval: %s, expected: %s", interval, expected) // should be at least the expected interval
+		assert.Check(t, interval > expected, "interval: %s, expected: %s", interval, expected)
 		assert.Check(t, cmp.DeepEqual(interval, expected, opt.DurationWithThreshold(jitterInterval)))
 	}
 }


### PR DESCRIPTION
I added a test which asserts that the jitter is never zero. You can see that it fails [here](https://buildkite.com/buildkite/roko/builds/54). It is "almost impossible" to fail this test if the jitter was working correctly.

This was happening because casting a float32 in the interval `[0,1)` to a `time.Duration` (which is an uint64 under the hood) will always result in 0.

To make the test deterministic, in the fix, I've ensured that the jitter is always a non-zero, i.e. the interval is `(0, jitterMax]`, instead of `[0, jitterMax)`.