### PR TITLE
ExponentialSubsecond strategy test case for 10 x 2sec

### DIFF
--- a/retrier_test.go
+++ b/retrier_test.go
@@ -316,6 +316,32 @@ func TestNextInterval_ExponentialSubsecondStrategy_1sec(t *testing.T) {
 	}, insomniac.sleepIntervals, DurationExact())
 }
 
+func TestNextInterval_ExponentialSubsecondStrategy_2sec(t *testing.T) {
+	t.Parallel()
+
+	insomniac := newInsomniac()
+	err := NewRetrier(
+		WithStrategy(ExponentialSubsecond(2*time.Second)),
+		WithMaxAttempts(10),
+		WithSleepFunc(insomniac.sleep),
+	).Do(func(_ *Retrier) error { return errDummy })
+	assert.ErrorIs(t, err, errDummy)
+
+	// initial delay of 2 grows to reasonable 90 seconds for 10 attempts,
+	// with total delay time of 233 seconds (~4 minutes).
+	assert.DeepEqual(t, []time.Duration{
+		2000 * time.Millisecond,
+		3216 * time.Millisecond,
+		5172 * time.Millisecond,
+		8317 * time.Millisecond,
+		13374 * time.Millisecond,
+		21508 * time.Millisecond,
+		34587 * time.Millisecond,
+		55619 * time.Millisecond,
+		89442 * time.Millisecond,
+	}, insomniac.sleepIntervals, DurationExact())
+}
+
 func TestNextInterval_ExponentialSubsecondStrategy_5sec(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This test is mostly helpful as documentation for the growth / total time / curve of this configuration.

> 10 x 2 sec exp -> 2, 3, 5, 8, 13, 21, 34, 55, 89 seconds (total delay: 233 seconds)

[Plotted](https://www.wolframalpha.com/input?i=y%3D2000%5E%28x%2F16+%2B+1%29+for+x+from+0+to+8):

<img width="369" alt="image" src="https://github.com/buildkite/roko/assets/15759/dcb24bbc-7a94-4f15-bdf8-a14f496758b7">
